### PR TITLE
adsprpc: map the persist buffer outside the mutex

### DIFF
--- a/src/fastrpc_apps_user.c
+++ b/src/fastrpc_apps_user.c
@@ -3947,6 +3947,7 @@ static int domain_init(int domain, int *dev) {
   }
   VERIFY(AEE_SUCCESS == (nErr = fastrpc_mem_open(domain)));
   VERIFY(AEE_SUCCESS == (nErr = apps_mem_init(domain)));
+  fastrpc_log_init(domain, dsppd);
 
   if (dom == CDSP_DOMAIN_ID) {
     panic_handle = get_adsp_current_process1_handle(domain);
@@ -4124,7 +4125,6 @@ static int fastrpc_apps_user_init(void) {
   VERIFY(AEE_SUCCESS == (nErr = PL_INIT(gpls)));
   VERIFY(AEE_SUCCESS == (nErr = PL_INIT(rpcmem)));
   fastrpc_mem_init();
-  fastrpc_log_init();
   fastrpc_config_init();
   pthread_mutex_init(&update_notif_list_mut, 0);
 #ifndef NO_HAL

--- a/src/fastrpc_log.c
+++ b/src/fastrpc_log.c
@@ -16,6 +16,7 @@
 #include "fastrpc_trace.h"
 #include "rpcmem_internal.h"
 #include "verify.h"
+#include "remote.h"
 
 #define PROPERTY_VALUE_MAX 72
 /* Create persist buffer of size 1 MB */
@@ -276,14 +277,13 @@ void HAP_debug(const char *msg, int level, const char *filename, int line) {
 #endif
 }
 
-void fastrpc_log_init() {
-  bool debug_build_type = false;
+void fastrpc_log_init(int domain, int dsppd) {
+  bool debug_build_type = false, locked = false;
   int nErr = AEE_SUCCESS, fd = -1;
   char build_type[PROPERTY_VALUE_MAX];
-  char *logfilename;
+  char *logfilename = NULL;
 
   pthread_mutex_init(&persist_buf.mut, 0);
-  pthread_mutex_lock(&persist_buf.mut);
   /*
    * Get build type by reading the target properties,
    * if buuid type is eng or userdebug allocate 1 MB persist buf.
@@ -298,26 +298,35 @@ void fastrpc_log_init() {
       debug_build_type = true;
 #endif
   }
-  if (persist_buf.buf == NULL && debug_build_type) {
-    /* Create a debug buffer to append DEBUG FARF level message. */
-    persist_buf.buf = (char *)rpcmem_alloc_internal(
-        RPCMEM_HEAP_ID_SYSTEM, RPCMEM_DEFAULT_FLAGS | RPCMEM_TRY_MAP_STATIC,
-        DEBUG_BUF_SIZE * sizeof(char));
-    if (persist_buf.buf) {
-      fd = rpcmem_to_fd(persist_buf.buf);
-      FARF(RUNTIME_RPC_HIGH, "%s: persist_buf.buf created %d size %d", __func__,
-           fd, DEBUG_BUF_SIZE);
-      /* Appending header to persist buffer, to identify the start address
-       * through script. */
+ if ((dsppd == USERPD || dsppd == AUDIO_STATICPD  ||
+      dsppd == SENSORS_STATICPD) && debug_build_type) {
+    pthread_mutex_lock(&persist_buf.mut);
+    locked = true;
+    if (persist_buf.buf == NULL) {
+      /* Create a debug buffer to append DEBUG FARF level message. */
+      VERIFYC(NULL != (persist_buf.buf =
+             (char *)rpcmem_alloc(RPCMEM_HEAP_ID_SYSTEM,
+             RPCMEM_DEFAULT_FLAGS, DEBUG_BUF_SIZE * sizeof(char))),
+             AEE_ENOMEMORY);
+      /*
+       * Appending header to persist buffer, to identify the start
+       * address through script.
+       */
       std_strlcpy(persist_buf.buf, DEBUF_BUF_TRACE, DEBUG_BUF_SIZE);
       persist_buf.size = strlen(DEBUF_BUF_TRACE) + 1;
-    } else {
-      nErr = AEE_ENORPCMEMORY;
-      FARF(ERROR, "Error 0x%x: %s allocation failed for persist_buf of size %d",
-           nErr, __func__, DEBUG_BUF_SIZE);
+      FARF(ALWAYS, "%s allocation done for persist_buf 0x%p size %d",
+             __func__, persist_buf.buf, DEBUG_BUF_SIZE);
     }
+     locked = false;
+    pthread_mutex_unlock(&persist_buf.mut);
+    VERIFYC(0 < (fd = rpcmem_to_fd_internal(persist_buf.buf)),
+            AEE_EBADFD);
+    VERIFY(AEE_SUCCESS == (nErr = fastrpc_mmap(domain, fd,
+            persist_buf.buf, 0, DEBUG_BUF_SIZE * sizeof(char),
+            FASTRPC_MAP_STATIC)));
+    FARF(ALWAYS, "%s mapping done for persist_buf 0x%p fd %d of size %d on domain %d",
+        __func__, persist_buf.buf, fd, DEBUG_BUF_SIZE, domain);
   }
-  pthread_mutex_unlock(&persist_buf.mut);
   logfilename = fastrpc_config_get_userspace_runtime_farf_file();
   if (logfilename) {
     log_userspace_file_fd = fopen(logfilename, "w");
@@ -329,6 +338,14 @@ void fastrpc_log_init() {
       FARF(RUNTIME_RPC_HIGH, "%s done\n", __func__);
     }
   }
+bail:
+  if (locked) {
+    pthread_mutex_unlock(&persist_buf.mut);
+  }
+  if (nErr) {
+    FARF(ERROR, "Error 0x%x: %s failed for persist_buf %p fd %d of size %d on domain %d",
+         nErr, __func__, persist_buf.buf, fd, DEBUG_BUF_SIZE, domain);
+  }  
 }
 
 void fastrpc_log_deinit() {


### PR DESCRIPTION
Currently, allocation and mapping of buffer is happening inside mutex.If mapping on one session gets stuck on DSP,other sessions will not be able to acquire the mutex and will get hung while getting spawned. Map the buffer outside the mutex.