### PR TITLE
Test Automation: Integrating GitHub Workflow for FastRPC and Meta-Qcom on LAVA

### DIFF
--- a/.github/workflows/build_linux_gnu.yml
+++ b/.github/workflows/build_linux_gnu.yml
@@ -1,63 +1,152 @@
-name: CI - Linux GNU Compilation
+name: CI - fastrpc Linux GNU Compilation
 
 on:
   push:
     branches:
-    - 'main'
-    - 'development'
+      - main
+      - development
   pull_request:
     branches:
-    - 'main'
-    - 'development'
+      - main
+      - development
   workflow_dispatch:
+  workflow_call:
+    outputs:
+      artifacts_url:
+        description: "URL to retrieve FastRPC build artifacts"
+        value: ${{ jobs.create-output.outputs.url }}
+
+env:
+  BASE_ARTIFACT_URL: https://quic-yocto-fileserver-1029608027416.us-central1.run.app
+  BUILD_ID: ${{ github.repository }}-${{ github.run_id }}-${{ github.run_attempt }}
+  Q_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
   build:
-
     runs-on: ubuntu-22.04
 
     steps:
-    - name: Git checkout
-      uses: actions/checkout@v4
+      - name: Git checkout
+        uses: actions/checkout@v4
 
-    - name: Install auto tools
-      run: |
-        sudo apt-get install automake
-    
-    - name: Download Linaro tools and untar
-      run: |
-        wget -c https://releases.linaro.org/components/toolchain/binaries/latest-7/aarch64-linux-gnu/gcc-linaro-7.5.0-2019.12-i686_aarch64-linux-gnu.tar.xz
-        tar xf gcc-linaro-7.5.0-2019.12-i686_aarch64-linux-gnu.tar.xz
+      - name: Install auto tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y automake
 
-    - name: Set Up Build Environment and compile code for LE platform
-      run: |
-  
-        # Set Up Build Environment
-        export PATH="$PWD/gcc-linaro-7.5.0-2019.12-i686_aarch64-linux-gnu/bin/:$PATH"
-        export CC=aarch64-linux-gnu-gcc
-        export CXX=aarch64-linux-gnu-g++
-        export AS=aarch64-linux-gnu-as
-        export LD=aarch64-linux-gnu-ld
-        export RANLIB=aarch64-linux-gnu-ranlib
-        export STRIP=aarch64-linux-gnu-strip
-        
-        # Compile the source code
-        chmod 777 gitcompile
-        ./gitcompile --host=aarch64-linux-gnu
+      - name: Download Linaro tools and untar
+        run: |
+          wget -c https://releases.linaro.org/components/toolchain/binaries/latest-7/aarch64-linux-gnu/gcc-linaro-7.5.0-2019.12-i686_aarch64-linux-gnu.tar.xz
+          tar xf gcc-linaro-7.5.0-2019.12-i686_aarch64-linux-gnu.tar.xz
 
-    - name: Verify the compiled binaries
-      run: |
-        echo "Verify the compiled binaries"
-        Files=("src/.libs/libadsp_default_listener.so
-          src/.libs/libadsprpc.so
-          src/.libs/libcdsp_default_listener.so
-          src/.libs/libcdsprpc.so
-          src/.libs/libsdsp_default_listener.so
-          src/.libs/libsdsprpc.so
-          src/adsprpcd
-          src/cdsprpcd
-          src/sdsprpcd")
-        for File in $Files
-        do 
-         if [ -f $File ] ; then echo $File " - Exists" ; else echo $File " - Not Exists" && exit -1 ; fi
-        done
+      - name: Set Up Build Environment and compile code for LE platform
+        run: |
+          export PATH="$PWD/gcc-linaro-7.5.0-2019.12-i686_aarch64-linux-gnu/bin/:$PATH"
+          export CC=aarch64-linux-gnu-gcc
+          export CXX=aarch64-linux-gnu-g++
+          export AS=aarch64-linux-gnu-as
+          export LD=aarch64-linux-gnu-ld
+          export RANLIB=aarch64-linux-gnu-ranlib
+          export STRIP=aarch64-linux-gnu-strip
+
+          chmod +x gitcompile
+          ./gitcompile --host=aarch64-linux-gnu
+
+      - name: Verify the compiled binaries
+        run: |
+          echo "Verifying compiled binaries..."
+          Files=(
+            "src/.libs/libadsp_default_listener.so"
+            "src/.libs/libadsprpc.so"
+            "src/.libs/libcdsp_default_listener.so"
+            "src/.libs/libcdsprpc.so"
+            "src/.libs/libsdsp_default_listener.so"
+            "src/.libs/libsdsprpc.so"
+            "src/adsprpcd"
+            "src/cdsprpcd"
+            "src/sdsprpcd"
+          )
+          for File in "${Files[@]}"; do
+            if [ -f "$File" ]; then
+              echo "$File - Exists"
+            else
+              echo "$File - Not Found"
+              exit 1
+            fi
+          done
+
+      - name: Archive FastRPC binaries
+        run: |
+          mkdir -p fastrpc-artifacts
+          cp src/.libs/*.so src/adsprpcd src/cdsprpcd src/sdsprpcd fastrpc-artifacts/
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: fastrpc-artifacts
+          path: fastrpc-artifacts/
+
+      - name: Publish artifacts to file server
+        run: |
+          echo "Uploading to file server..."
+          echo "BASE_ARTIFACT_URL: ${BASE_ARTIFACT_URL}"
+          echo "BUILD_ID: ${BUILD_ID}"
+          echo "Full URL: ${BASE_ARTIFACT_URL}/${BUILD_ID}/fastrpc-artifacts/"
+          echo "${BASE_ARTIFACT_URL}/${BUILD_ID}/fastrpc-artifacts/" > build_url
+
+
+      - name: Upload build URL
+        uses: actions/upload-artifact@v4
+        with:
+          name: build_url
+          path: build_url
+
+  test:
+    name: Install FastRPC Binaries
+    runs-on: ubuntu-22.04
+    needs: build
+
+    steps:
+      - name: Construct and print download URL
+        run: |
+          ARTIFACT_URL="${BASE_ARTIFACT_URL}/${BUILD_ID}/fastrpc-artifacts/fastrpc-artifacts.zip"
+          echo "Downloading from: $ARTIFACT_URL"
+          echo $ARTIFACT_URL > artifact_url.txt
+
+      - name: Download and extract artifacts
+        run: |
+          cd /tmp
+          ARTIFACT_URL=$(cat $GITHUB_WORKSPACE/artifact_url.txt)
+          wget --header="Authentication: ${Q_GITHUB_TOKEN}" "$ARTIFACT_URL" -O fastrpc.zip
+          if [ -f fastrpc.zip ]; then
+            echo "Download successful."
+          else
+            echo "Download failed."
+            exit 1
+          fi
+          unzip fastrpc.zip -d fastrpc
+
+      - name: Install binaries
+        run: |
+          sudo cp /tmp/fastrpc/*.so /usr/lib64/
+          sudo cp /tmp/fastrpc/adsprpcd /usr/bin/
+          sudo cp /tmp/fastrpc/cdsprpcd /usr/bin/
+          sudo cp /tmp/fastrpc/sdsprpcd /usr/bin/
+          sudo chmod +x /usr/bin/adsprpcd /usr/bin/cdsprpcd /usr/bin/sdsprpcd
+
+  create-output:
+    needs: build
+    outputs:
+      url: ${{ steps.print-output.outputs.url }}
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Download build_url artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: build_url
+
+      - name: Print and set output
+        id: print-output
+        run: |
+          url=$(cat build_url)
+          echo "url=${url}" >> $GITHUB_OUTPUT

--- a/.github/workflows/fastrpc-lava-tests.yml
+++ b/.github/workflows/fastrpc-lava-tests.yml
@@ -1,0 +1,129 @@
+name: Fastrpc lava Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+env:
+  BASE_ARTIFACT_URL: https://quic-yocto-fileserver-1029608027416.us-central1.run.app/qualcomm-linux/meta-qcom-15010641606-1
+
+jobs:
+  prepare-job-list:
+    runs-on: ubuntu-latest
+    outputs:
+      jobmatrix: ${{ steps.listjobs.outputs.jobmatrix }}
+    steps:
+      - name: Clone fastrpc repository
+        uses: actions/checkout@v4
+        with:
+          repository: quic/fastrpc
+          path: fastrpc
+          fetch-depth: 0
+
+      - name: Clone meta-qcom repository
+        uses: actions/checkout@v4
+        with:
+          repository: qualcomm-linux/meta-qcom
+          path: meta-qcom
+          fetch-depth: 0
+
+      - name: Print trigger
+        run: |
+          echo "Triggered by ${{ github.event_name }}"
+
+      - name: "List jobs"
+        id: listjobs
+        run: |
+          JOBFILES=$(find meta-qcom/ci/lava/ -name *.yaml)
+          JOBFILES=$(echo "$JOBFILES" | sed -e "s/^/\"/" | sed -e "s/$/\",/" | tr -d "\n" | sed -e "s/.$//")
+          JOBFILES="[${JOBFILES}]"
+          J=$(jq -cn --argjson jobfiles "$JOBFILES" '{target: $jobfiles}')
+          echo "jobmatrix=$J" >> $GITHUB_OUTPUT
+          echo "Preparing test job files"
+
+  submit-job:
+    needs: prepare-job-list
+    runs-on: ubuntu-latest
+    strategy:
+      matrix: ${{ fromJson(needs.prepare-job-list.outputs.jobmatrix) }}
+    steps:
+      - name: Clone fastrpc repository
+        uses: actions/checkout@v4
+        with:
+          repository: quic/fastrpc
+          path: fastrpc
+          fetch-depth: 0
+
+      - name: Clone meta-qcom repository
+        uses: actions/checkout@v4
+        with:
+          repository: qualcomm-linux/meta-qcom
+          path: meta-qcom
+          fetch-depth: 0
+
+      - name: "Update test definition ${{ matrix.target }}"
+        run: |
+          TARGET=${{ matrix.target }}
+          FIND_PATH="${TARGET#*/}"
+          DEVICE_TYPE_PATH="${FIND_PATH%/*}"
+          DEVICE_TYPE="${DEVICE_TYPE_PATH#*/}"
+          DEVICE_TYPE=$(basename "$DEVICE_TYPE_PATH")
+          BUILD_FILE_NAME="core-image-base-${DEVICE_TYPE}.rootfs.qcomflash.tar.gz"
+          BUILD_DOWNLOAD_URL="${BASE_ARTIFACT_URL}/${DEVICE_TYPE}/${BUILD_FILE_NAME}"
+          sed -i "s|{{DEVICE_TYPE}}|${DEVICE_TYPE}|g" "${{ matrix.target }}"
+          sed -i "s|{{GITHUB_SHA}}|${GITHUB_SHA}|g" "${{ matrix.target }}"
+          sed -i "s|{{BUILD_DOWNLOAD_URL}}|${BUILD_DOWNLOAD_URL}|g" "${{ matrix.target }}"
+          sed -i "s|{{BUILD_FILE_NAME}}|${BUILD_FILE_NAME}|g" "${{ matrix.target }}"
+          sed -i "s|{{GITHUB_RUN_ID}}|${GITHUB_RUN_ID}|g" "${{ matrix.target }}"
+          cat "${{ matrix.target }}"
+
+      - name: Submit ${{ matrix.target }}
+        timeout-minutes: 20
+        uses: foundriesio/lava-action@v6
+        with:
+          lava_token: ${{ secrets.LAVATOKEN }}
+          lava_url: 'lava.infra.foundries.io'
+          job_definition: ${{ matrix.target }}
+          wait_for_job: true
+          fail_action_on_failure: false
+          save_result_as_artifact: true
+          save_job_details: true
+
+  publish-test-results:
+    name: "Publish Tests Results"
+    needs: submit-job
+    runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      pull-requests: write
+
+    steps:
+      - name: Download Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: "List files"
+        run: |
+          echo $GITHUB_WORKSPACE
+          ls -R $GITHUB_WORKSPACE
+
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        with:
+          files: "${{ github.workspace }}/artifacts/**/*.xml"
+
+      - name: Publish Test Job Details
+        run: |
+          for json_file in $(find ${{ github.workspace }} -name "test-job-*.json")
+          do
+              DEVICE_TYPE=$(cat "$json_file" | jq -r ".requested_device_type")
+              URL=$(cat "$json_file" | jq -r ".url")
+              JOB_ID=$(cat "$json_file" | jq -r ".id")
+              echo " * [Job $JOB_ID on $EVICE_TYPE"
+              echo " * [Job $JOB_ID on $DEVICETYPE" >> $GITHUB_STEP_SUMMARY
+          done


### PR DESCRIPTION
This commit introduces a GitHub Actions workflow named "Fastrpc lava Tests" to automate the testing of FastRPC builds using LAVA infrastructure. The workflow performs the following:

- Clones the `fastrpc` and `meta-qcom` repositories.
- Dynamically generates a matrix of LAVA job files.
- Submits each job to the LAVA server using the `foundriesio/lava-action`.
- Publishes test results and job details as GitHub artifacts and summaries.

This setup enables continuous integration and validation of FastRPC code on supported Qualcomm platforms.