### PR TITLE
Fix: Correct fastrpc_test binary path in documentation

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -14,7 +14,7 @@ After building the application, the following files and directories need to be p
 
 Copy the following files and directories to `/usr/bin` on the target device:
 
-- `/path/to/your/fastrpc/test/.libs/fastrpc_test`
+- `/path/to/your/fastrpc/test/fastrpc_test`
 - `/path/to/your/fastrpc/test/android` (if using Android)
 - `/path/to/your/fastrpc/test/linux` (if using Linux)
 - `/path/to/your/fastrpc/test/v68`


### PR DESCRIPTION
This PR updates the documentation to reflect the correct location of the fastrpc_test binary. The previous path was outdated or incorrect, which could lead to confusion or execution errors during deployment or testing.