### PR TITLE
test: Update environment handling and README for fastrpc_test

### DIFF
--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -5,7 +5,9 @@ bin_PROGRAMS = fastrpc_test
 fastrpc_test_SOURCES = fastrpc_test.c
 
 # Define the compiler flags for the test program
-fastrpc_test_CFLAGS = -I$(top_srcdir)/inc -DUSE_SYSLOG
+fastrpc_test_CFLAGS = -I$(top_srcdir)/inc -DUSE_SYSLOG \
+                      -Dtestlibdir=\"$(testlibdir)\" \
+                      -Dtestdspdir=\"$(testdspdir)\"
 
 if ANDROID_CC
 USE_LOG = -llog

--- a/test/README.md
+++ b/test/README.md
@@ -12,28 +12,20 @@ After building the application, the following files and directories need to be p
 4. **v68 Directory**: Contains skeletons for the v68 architecture version.
 5. **v75 Directory**: Contains skeletons for the v75 architecture version.
 
-Copy the following files and directories to `/usr/bin` on the target device:
+### Installing the Test
 
-- `/path/to/your/fastrpc/test/.libs/fastrpc_test`
-- `/path/to/your/fastrpc/test/android` (if using Android)
-- `/path/to/your/fastrpc/test/linux` (if using Linux)
-- `/path/to/your/fastrpc/test/v68`
-- `/path/to/your/fastrpc/test/v75`
+Use `make install` to install the libraries and the executable to the appropriate directories:
 
-**Note**: Push the `android` directory if you are using the Android platform, and the `linux` directory if you are using the Linux platform.
+```bash
+make install
+```
 
 ## Running the Test
 
-To run the test application, follow these steps:
-
-1. Navigate to the `/usr/bin` directory on the device.
-2. Execute the `fastrpc_test` binary with the appropriate options.
-
-Example command:
+To run the test application, use the following command:
 
 ```bash
-cd /usr/bin
-./fastrpc_test -d 3 -U 1 -t linux -a v68
+fastrpc_test -d 3 -U 1 -t linux -a v68
 ```
 
 ### Options

--- a/test/fastrpc_test.c
+++ b/test/fastrpc_test.c
@@ -39,9 +39,10 @@ int main(int argc, char *argv[]) {
     bool is_unsignedpd_enabled = true;  // Default to unsigned PD
     const char *target = "linux";  // Default target platform
     const char *arch_version = "v68";  // Default architecture version
-    char abs_lib_path[PATH_MAX];
     char ld_lib_path[PATH_MAX];
     char dsp_lib_path[PATH_MAX];
+    char *current_ld_lib_path;
+    char *current_dsp_lib_path;
     DIR *dir;
     struct dirent *entry;
     char full_lib_path[PATH_MAX];
@@ -60,6 +61,11 @@ int main(int argc, char *argv[]) {
                 break;
             case 't':
                 target = optarg;
+                if (strcmp(target, "linux") != 0 && strcmp(target, "android") != 0) {
+                    printf("\nERROR: Invalid target platform (-t). Must be linux or android.\n");
+                    print_usage();
+                    return -1;
+                }
                 break;
             case 'a':
                 arch_version = optarg;
@@ -75,44 +81,37 @@ int main(int argc, char *argv[]) {
         }
     }
 
-    // Construct the absolute library path
-    snprintf(abs_lib_path, sizeof(abs_lib_path), "%s", target);
-
-    if (realpath(abs_lib_path, abs_lib_path) == NULL) {
-        fprintf(stderr, "Error resolving path %s: %s\n", abs_lib_path, strerror(errno));
-        return -1;
+    current_ld_lib_path = getenv("LD_LIBRARY_PATH");
+    if (current_ld_lib_path) {
+        snprintf(ld_lib_path, sizeof(ld_lib_path), "%s;%s", current_ld_lib_path, testlibdir);
+    } else {
+        snprintf(ld_lib_path, sizeof(ld_lib_path), "%s", testlibdir);
     }
-
-    // Construct the absolute DSP library path
-    snprintf(dsp_lib_path, sizeof(dsp_lib_path), "%s", arch_version);
-
-    if (realpath(dsp_lib_path, dsp_lib_path) == NULL) {
-        fprintf(stderr, "Error resolving path %s: %s\n", dsp_lib_path, strerror(errno));
-        return -1;
-    }
-
-    // Construct LD_LIBRARY_PATH and DSP_LIBRARY_PATH
-    snprintf(ld_lib_path, sizeof(ld_lib_path), "%s", abs_lib_path);
-
     if (setenv("LD_LIBRARY_PATH", ld_lib_path, 1) != 0) {
         fprintf(stderr, "Error setting LD_LIBRARY_PATH: %s\n", strerror(errno));
         return -1;
     }
 
+    current_dsp_lib_path = getenv("DSP_LIBRARY_PATH");
+    if (current_dsp_lib_path) {
+        snprintf(dsp_lib_path, sizeof(dsp_lib_path), "%s;%s/%s", current_dsp_lib_path, testdspdir, arch_version);
+    } else {
+        snprintf(dsp_lib_path, sizeof(dsp_lib_path), "%s/%s", testdspdir, arch_version);
+    }
     if (setenv("DSP_LIBRARY_PATH", dsp_lib_path, 1) != 0) {
         fprintf(stderr, "Error setting DSP_LIBRARY_PATH: %s\n", strerror(errno));
         return -1;
     }
 
-    dir = opendir(abs_lib_path);
+    dir = opendir(testlibdir);
     if (!dir) {
-        fprintf(stderr, "Error opening directory %s: %s\n", abs_lib_path, strerror(errno));
+        fprintf(stderr, "Error opening directory %s: %s\n", testlibdir, strerror(errno));
         return -1;
     }
 
     while ((entry = readdir(dir)) != NULL) {
         if (entry->d_type == DT_REG && strstr(entry->d_name, ".so")) {
-            snprintf(full_lib_path, sizeof(full_lib_path), "%s/%s", abs_lib_path, entry->d_name);
+            snprintf(full_lib_path, sizeof(full_lib_path), "%s/%s", testlibdir, entry->d_name);
 
             lib_handle = dlopen(full_lib_path, RTLD_LAZY);
             if (!lib_handle) {


### PR DESCRIPTION
- Update fastrpc_test.c to append testlibdir and testdspdir to LD_LIBRARY_PATH and DSP_LIBRARY_PATH instead of overwriting them.
- Modify Makefile.am to pass -Dtestlibdir and -Dtestdspdir for correct environment variable setup.
- Revise README.md to use make install for installation and simplify run instructions, removing the need to change directories.