### PR TITLE
Fix warning: variable might be uninitialized

### DIFF
--- a/inc/fastrpc_ioctl.h
+++ b/inc/fastrpc_ioctl.h
@@ -57,8 +57,7 @@
 	#define DEFAULT_DEVICE ""
 #endif
 
-#define INITIALIZE_REMOTE_ARGS(total)	struct fastrpc_invoke_args* args = NULL; \
-					int *pfds = NULL; \
+#define INITIALIZE_REMOTE_ARGS(total)	int *pfds = NULL; \
 					unsigned *pattrs = NULL; \
 					args = (struct fastrpc_invoke_args*) calloc(sizeof(*args), total);	\
 					if(args==NULL) { 	\

--- a/src/fastrpc_apps_user.c
+++ b/src/fastrpc_apps_user.c
@@ -1168,6 +1168,7 @@ int remote_handle_invoke_domain(int domain, remote_handle handle,
   fastrpc_timer frpc_timer;
   int trace_marker_fd = hlist[domain].trace_marker_fd;
   bool trace_enabled = false;
+  struct fastrpc_invoke_args* args = NULL; 
 
   if (IS_QTF_TRACING_ENABLED(hlist[domain].procattrs) &&
       !IS_STATIC_HANDLE(handle) && trace_marker_fd > 0) {


### PR DESCRIPTION
Move the definition of args to the beginning of the function(remote_handle_invoke_domain), which seems to solve the variable might be uninitialized warning.
Since there is a goto bail later in the function, the compiler might think that args could still be used without a definition.

