### PR TITLE
Avoid issue and PR closure by stale-issues workflow

### DIFF
--- a/.github/workflows/stale-issues.yaml
+++ b/.github/workflows/stale-issues.yaml
@@ -13,12 +13,12 @@ jobs:
     steps:
     - uses: actions/stale@v9
       with:
-        stale-issue-message: 'This issue has been marked as stale due to 60 days of inactivity. To prevent automatic closure in 10 days, remove the stale label or add a comment. You can reopen a closed issue at any time.'
-        stale-pr-message: 'This pull request has been marked as stale due to 60 days of inactivity. To prevent automatic closure in 10 days, remove the stale label or add a comment. You can reopen a closed pull request at any time.'
+        stale-issue-message: 'This issue has been marked as stale due to 60 days of inactivity.'
+        stale-pr-message: 'This pull request has been marked as stale due to 60 days of inactivity.'
         exempt-issue-labels: bug,enhancement
         exempt-pr-labels: bug,enhancement
         days-before-stale: 60
-        days-before-close: 10
+        days-before-close: -1
         remove-stale-when-updated: true
         remove-issue-stale-when-updated: true
         remove-pr-stale-when-updated: true


### PR DESCRIPTION
stale-issues workflow is automatically closing inactive PRs and
issues. Closing of PRs and issues without any proper resolution
is a bad idea as it would result in loss of valuable context and
also discourage contributors. This also causes missed opportunities
for improvement and increases chances of issue recurrence. Modifying
stale-issues workflow to just mark the inactive PRs and issues as
stale and not close it.