### PR TITLE
Clean-up: Remove unused Android-specific DSP HAL code

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,6 +1,6 @@
 lib_LTLIBRARIES =
 
-LIBDSPRPC_CFLAGS = -fno-short-enums -U_DEBUG -DARM_ARCH_7A -DLE_ENABLE -DNO_HAL -DENABLE_UPSTREAM_DRIVER_INTERFACE -DUSE_SYSLOG -I$(top_srcdir)/inc
+LIBDSPRPC_CFLAGS = -fno-short-enums -U_DEBUG -DARM_ARCH_7A -DLE_ENABLE -DENABLE_UPSTREAM_DRIVER_INTERFACE -DUSE_SYSLOG -I$(top_srcdir)/inc
 
 LIBDSPRPC_SOURCES = \
 		fastrpc_apps_user.c \
@@ -102,19 +102,19 @@ bin_PROGRAMS = adsprpcd cdsprpcd sdsprpcd
 adsprpcddir = $(libdir)
 adsprpcd_SOURCES = adsprpcd.c
 adsprpcd_DEPENDENCIES = libadsp_default_listener.la
-adsprpcd_CFLAGS = -I$(top_srcdir)/inc -DDEFAULT_DOMAIN_ID=0 -DUSE_SYSLOG -DNO_HAL
+adsprpcd_CFLAGS = -I$(top_srcdir)/inc -DDEFAULT_DOMAIN_ID=0 -DUSE_SYSLOG 
 adsprpcd_LDADD = -ldl $(USE_LOG)
 
 
 cdsprpcddir = $(libdir)
 cdsprpcd_SOURCES = cdsprpcd.c
 cdsprpcd_DEPENDENCIES = libcdsp_default_listener.la
-cdsprpcd_CFLAGS = -I$(top_srcdir)/inc -DDEFAULT_DOMAIN_ID=3 -DUSE_SYSLOG -DNO_HAL
+cdsprpcd_CFLAGS = -I$(top_srcdir)/inc -DDEFAULT_DOMAIN_ID=3 -DUSE_SYSLOG 
 cdsprpcd_LDADD =  -ldl $(USE_LOG)
 
 
 sdsprpcddir = $(libdir)
 sdsprpcd_SOURCES = sdsprpcd.c
 sdsprpcd_DEPENDENCIES = libsdsp_default_listener.la
-sdsprpcd_CFLAGS = -I$(top_srcdir)/inc -DDEFAULT_DOMAIN_ID=2 -DUSE_SYSLOG -DNO_HAL
+sdsprpcd_CFLAGS = -I$(top_srcdir)/inc -DDEFAULT_DOMAIN_ID=2 -DUSE_SYSLOG
 sdsprpcd_LDADD =  -ldl $(USE_LOG)

--- a/src/adsprpcd.c
+++ b/src/adsprpcd.c
@@ -17,9 +17,6 @@
 #ifndef ADSP_DEFAULT_LISTENER_NAME
 #define ADSP_DEFAULT_LISTENER_NAME "libadsp_default_listener.so"
 #endif
-#ifndef ADSP_LIBHIDL_NAME
-#define ADSP_LIBHIDL_NAME "libhidlbase.so"
-#endif
 
 typedef int (*adsp_default_listener_start_t)(int argc, char *argv[]);
 
@@ -27,16 +24,10 @@ int main(int argc, char *argv[]) {
 
   int nErr = 0;
   void *adsphandler = NULL;
-#ifndef NO_HAL
-  void *libhidlbaseHandler = NULL;
-#endif
   adsp_default_listener_start_t listener_start;
 
   VERIFY_EPRINTF("adsp daemon starting");
-#ifndef NO_HAL
-  if(NULL != (libhidlbaseHandler = dlopen(ADSP_LIBHIDL_NAME, RTLD_NOW))) {
-#endif
-	  while (1) {
+  while (1) {
 		if(NULL != (adsphandler = dlopen(ADSP_DEFAULT_LISTENER_NAME, RTLD_NOW))) {
 		  if(NULL != (listener_start =
 		(adsp_default_listener_start_t)dlsym(adsphandler, "adsp_default_listener_start"))) {
@@ -54,13 +45,7 @@ int main(int argc, char *argv[]) {
 		}
 		VERIFY_EPRINTF("adsp daemon will restart after 25ms...");
 		usleep(25000);
-	  }
-#ifndef NO_HAL
-	  if(0 != dlclose(libhidlbaseHandler)) {
-		  VERIFY_EPRINTF("libhidlbase dlclose failed");
-	  }
   }
-#endif
   VERIFY_EPRINTF("adsp daemon exiting %x", nErr);
 
   return nErr;

--- a/src/cdsprpcd.c
+++ b/src/cdsprpcd.c
@@ -16,9 +16,6 @@
 #ifndef CDSP_DEFAULT_LISTENER_NAME
 #define CDSP_DEFAULT_LISTENER_NAME "libcdsp_default_listener.so"
 #endif
-#ifndef CDSP_LIBHIDL_NAME
-#define CDSP_LIBHIDL_NAME "libhidlbase.so"
-#endif
 
 typedef int (*adsp_default_listener_start_t)(int argc, char *argv[]);
 
@@ -26,16 +23,10 @@ int main(int argc, char *argv[]) {
 
   int nErr = 0;
   void *cdsphandler = NULL;
-#ifndef NO_HAL
-  void *libhidlbaseHandler = NULL;
-#endif
   adsp_default_listener_start_t listener_start;
 
   VERIFY_EPRINTF("cdsp daemon starting");
-#ifndef NO_HAL
-  if (NULL != (libhidlbaseHandler = dlopen(CDSP_LIBHIDL_NAME, RTLD_NOW))) {
-#endif
-    while (1) {
+  while (1) {
       if (NULL !=
           (cdsphandler = dlopen(CDSP_DEFAULT_LISTENER_NAME, RTLD_NOW))) {
         if (NULL != (listener_start = (adsp_default_listener_start_t)dlsym(
@@ -55,13 +46,7 @@ int main(int argc, char *argv[]) {
       }
       VERIFY_EPRINTF("cdsp daemon will restart after 100ms...");
       usleep(100000);
-    }
-#ifndef NO_HAL
-    if (0 != dlclose(libhidlbaseHandler)) {
-      VERIFY_EPRINTF("libhidlbase dlclose failed");
-    }
   }
-#endif
   VERIFY_EPRINTF("cdsp daemon exiting %x", nErr);
 
   return nErr;


### PR DESCRIPTION
This PR addresses Issue #215 by removing the unused DSP HAL implementation. The HAL code was Android-specific and not utilized in the current DSP setup. Cleaning it up helps reduce maintenance overhead and improves code clarity.

- Verified build passes without HAL dependencies
- No functional impact expected

Please review and let me know if any additional cleanup is needed.