### PR TITLE
CI: Switch all reusable workflow references to 'development' branch

### DIFF
--- a/.github/actions/lava_job_render/action.yml
+++ b/.github/actions/lava_job_render/action.yml
@@ -80,7 +80,7 @@ runs:
 
     - name: Upload metadata.json
       id: upload_metadata
-      uses: qualcomm/fastrpc/.github/actions/aws_s3_helper@main
+      uses: qualcomm/fastrpc/.github/actions/aws_s3_helper@development
       with:
         local_file: ../job_render/data/metadata.json
         s3_bucket: qli-prd-fastrpc-gh-artifacts

--- a/.github/workflows/loading.yml
+++ b/.github/workflows/loading.yml
@@ -1,5 +1,4 @@
----
-name: _loading
+name: loading
 description: Load required parameters for the subsequent jobs
 
 on:
@@ -25,4 +24,4 @@ jobs:
 
       - name: Load Parameters
         id: loading
-        uses: qualcomm/fastrpc/.github/actions/loading@main
+        uses: qualcomm/fastrpc/.github/actions/loading@development

--- a/.github/workflows/pre_merge.yml
+++ b/.github/workflows/pre_merge.yml
@@ -1,4 +1,14 @@
 name: pre_merge
+description: |
+  This workflow defines the pre_merge CI process for the fastrpc repository.
+  It is triggered on pushes to 'main' or 'development' branches,
+  on pull request events (opened, synchronize, reopened) targeting 'main' or 'development',
+  or manually via workflow_dispatch.
+  Loading: Loads the build matrix from MACHINES.json.
+  Build: Syncs and Builds code for each machine/firmware pair using sync_build.yml.
+  Test: Runs LAVA tests using built artifacts via test.yml.
+  All jobs use reusable workflows and inherit secrets from the caller.
+
 on:
   push:
     branches:
@@ -15,7 +25,7 @@ jobs:
 
   # The loading job will load the build matrix from MACHINES.json
   loading:
-    uses: qualcomm/fastrpc/.github/workflows/loading.yml@main
+    uses: qualcomm/fastrpc/.github/workflows/loading.yml@development
     secrets: inherit
 
   # Each job in build and test will run for every {machine, firmware} pair
@@ -26,7 +36,7 @@ jobs:
     strategy:
       matrix:
         include: ${{ fromJSON(needs.loading.outputs.build_matrix) }}
-    uses: qualcomm/fastrpc/.github/workflows/sync_build.yml@main
+    uses: qualcomm/fastrpc/.github/workflows/sync_build.yml@development
     secrets: inherit
     with:
       docker_image: fastrpc-image:latest
@@ -37,7 +47,7 @@ jobs:
   # from the loading job. It will use the test.yml workflow to run tests.
   test:
     needs: [loading, build]
-    uses: qualcomm/fastrpc/.github/workflows/test.yml@main
+    uses: qualcomm/fastrpc/.github/workflows/test.yml@development
     secrets: inherit
     with:
       docker_image: fastrpc-image:latest

--- a/.github/workflows/sync_build.yml
+++ b/.github/workflows/sync_build.yml
@@ -1,5 +1,10 @@
-name: Sync and build 
-description: sync and builds fastrpc code for a specified machine using a Docker image
+name: Sync and build
+description: |
+  This reusable workflow syncs and builds FastRPC code for a specified machine and firmware 
+  using a Docker image. It performs code checkout, Docker image build, workspace sync, 
+  kernel compilation, and artifact packaging. Key build outputs (Image, ramdisk, modules, DTB) 
+  are uploaded to S3, and the runner workspace is cleaned to manage disk usage. A summary of 
+  the build status is added to the GitHub Actions summary.
 
 on:
   workflow_call:
@@ -31,20 +36,20 @@ jobs:
           fetch-depth: 1
 
       - name: Build fastrpc docker image
-        uses: qualcomm/fastrpc/.github/actions/build_docker_image@main
+        uses: qualcomm/fastrpc/.github/actions/build_docker_image@development
         with:
           image: ${{ inputs.docker_image }}
 
       - name: Sync codebase
         id: sync
-        uses: qualcomm/fastrpc/.github/actions/sync@main
+        uses: qualcomm/fastrpc/.github/actions/sync@development
         with:
           machine: ${{ inputs.machine }}
           firmware: ${{ inputs.firmware }}
 
       - name: Build workspace
         id: build_workspace
-        uses: qualcomm/fastrpc/.github/actions/build@main
+        uses: qualcomm/fastrpc/.github/actions/build@development
         with:
           docker_image: ${{ inputs.docker_image }}
           workspace_path: ${{ steps.sync.outputs.workspace_path }}
@@ -70,7 +75,7 @@ jobs:
           cat "$workspace/artifacts/file_list.txt"
 
       - name: Upload artifacts
-        uses: qualcomm/fastrpc/.github/actions/aws_s3_helper@main
+        uses: qualcomm/fastrpc/.github/actions/aws_s3_helper@development
         with:
           s3_bucket: qli-prd-fastrpc-gh-artifacts
           # local_file points to the list of files to upload

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,4 @@
 name: test
-
 description: |
   Run tests on LAVA for a specified machine using a Docker image.
   This reusable GitHub Actions workflow executes FastRPC tests on LAVA infrastructure.
@@ -45,7 +44,7 @@ jobs:
           fetch-depth: 0
 
       - name: Build fastrpc docker image
-        uses: qualcomm/fastrpc/.github/actions/build_docker_image@main
+        uses: qualcomm/fastrpc/.github/actions/build_docker_image@development
         with:
           image: ${{ inputs.docker_image }}
 
@@ -78,7 +77,7 @@ jobs:
             core.setOutput("LAVANAME", lavaname);
 
       - name: Create fastrpc - lava job definition
-        uses: qualcomm/fastrpc/.github/actions/lava_job_render@main
+        uses: qualcomm/fastrpc/.github/actions/lava_job_render@development
         id: create_job_definition
         with:
           docker_image: ${{ inputs.docker_image }}


### PR DESCRIPTION
### Summary
This PR updates all reusable workflow references in the FastRPC CI configuration to point to the `development` branch instead of `main`.

### Reason
The latest CI logic and improvements are maintained in the `development` branch. This change ensures that all workflows use the most current and tested configurations during pre-merge validation.