### PR TITLE
Fix ramdisk unpack and repack logic for fastrpc validation

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -87,9 +87,7 @@ runs:
         cp -rf src/adsprpcd src/cdsprpcd src/sdsprpcd ${{ inputs.workspace_path }}/artifacts/ramdisk_fastrpc/usr/bin/
 
         echo "Copy fastrpc test files"
-        cp -rf test/fastrpc_test ${{ inputs.workspace_path }}/artifacts/ramdisk_fastrpc/usr/bin
-        cp -rf test/linux/* ${{ inputs.workspace_path }}/artifacts/ramdisk_fastrpc/usr/bin
-        cp -rf test/v75/* ${{ inputs.workspace_path }}/artifacts/ramdisk_fastrpc/usr/bin
+        cp -rf test/* ${{ inputs.workspace_path }}/artifacts/ramdisk_fastrpc/usr/bin
 
         echo "Package FastRPC firmware files"
         cp -r ${{ inputs.workspace_path }}/firmware_dir/* ${{ inputs.workspace_path }}/artifacts/ramdisk_fastrpc/
@@ -100,7 +98,9 @@ runs:
         ls -la ${{ inputs.workspace_path }}/artifacts/ramdisk_fastrpc/usr/lib/
 
         cd ${{ inputs.workspace_path }}/artifacts/
-        find ramdisk_fastrpc | cpio -o -H newc > ramdisk_fastrpc.cpio
+        cd ramdisk_fastrpc
+        find . | cpio -o -H newc > ../ramdisk_fastrpc.cpio
+        cd ..
         gzip -9 ramdisk_fastrpc.cpio
         mv ramdisk_fastrpc.cpio.gz ramdisk_fastrpc.gz
 
@@ -109,8 +109,7 @@ runs:
       run: |
         echo "Unpack and mount ramdisk"
         cd ${{ inputs.workspace_path }}/artifacts
-
-        # Decompress the ramdisk.gz safely
+        mkdir -p ramdisk_test
         gunzip -c ramdisk_fastrpc.gz > ramdisk_test/ramdisk
 
         echo "Unpacking ramdisk"

--- a/.github/actions/lava_job_render/action.yml
+++ b/.github/actions/lava_job_render/action.yml
@@ -80,7 +80,7 @@ runs:
 
     - name: Upload metadata.json
       id: upload_metadata
-      uses: qualcomm/fastrpc/.github/actions/aws_s3_helper@main
+      uses: qualcomm/fastrpc/.github/actions/aws_s3_helper@development
       with:
         local_file: ../job_render/data/metadata.json
         s3_bucket: qli-prd-fastrpc-gh-artifacts

--- a/.github/actions/loading/action.yml
+++ b/.github/actions/loading/action.yml
@@ -39,12 +39,12 @@ runs:
             core.setFailed(`Failed to load or parse MACHINES.json: ${err.message}`);
             return;
           }
-          # Slim matrix for better job visibility
+          // Slim matrix for better job visibility
           const slim_matrix = Object.entries(file).map(([machine, [firmware]]) => ({ machine, firmware }));
           core.setOutput('build_matrix', JSON.stringify(slim_matrix));
           console.log(slim_matrix);
 
-          # Full matrix to pass to test jobs
+          // Full matrix to pass to test jobs
           const complete_matrix = Object.entries(file).map(([machine, [firmware, lavaname]]) => ({
             machine,
             firmware,

--- a/.github/workflows/loading.yml
+++ b/.github/workflows/loading.yml
@@ -1,5 +1,4 @@
----
-name: _loading
+name: loading
 description: Load required parameters for the subsequent jobs
 
 on:
@@ -25,4 +24,4 @@ jobs:
 
       - name: Load Parameters
         id: loading
-        uses: qualcomm/fastrpc/.github/actions/loading@main
+        uses: qualcomm/fastrpc/.github/actions/loading@development

--- a/.github/workflows/pre_merge.yml
+++ b/.github/workflows/pre_merge.yml
@@ -1,4 +1,14 @@
 name: pre_merge
+description: |
+  This workflow defines the pre_merge CI process for the fastrpc repository.
+  It is triggered on pushes to 'main' or 'development' branches,
+  on pull request events (opened, synchronize, reopened) targeting 'main' or 'development',
+  or manually via workflow_dispatch.
+  Loading: Loads the build matrix from MACHINES.json.
+  Build: Syncs and Builds code for each machine/firmware pair using sync_build.yml.
+  Test: Runs LAVA tests using built artifacts via test.yml.
+  All jobs use reusable workflows and inherit secrets from the caller.
+
 on:
   push:
     branches:
@@ -15,7 +25,7 @@ jobs:
 
   # The loading job will load the build matrix from MACHINES.json
   loading:
-    uses: qualcomm/fastrpc/.github/workflows/loading.yml@main
+    uses: qualcomm/fastrpc/.github/workflows/loading.yml@development
     secrets: inherit
 
   # Each job in build and test will run for every {machine, firmware} pair
@@ -26,7 +36,7 @@ jobs:
     strategy:
       matrix:
         include: ${{ fromJSON(needs.loading.outputs.build_matrix) }}
-    uses: qualcomm/fastrpc/.github/workflows/sync_build.yml@main
+    uses: qualcomm/fastrpc/.github/workflows/sync_build.yml@development
     secrets: inherit
     with:
       docker_image: fastrpc-image:latest
@@ -37,7 +47,7 @@ jobs:
   # from the loading job. It will use the test.yml workflow to run tests.
   test:
     needs: [loading, build]
-    uses: qualcomm/fastrpc/.github/workflows/test.yml@main
+    uses: qualcomm/fastrpc/.github/workflows/test.yml@development
     secrets: inherit
     with:
       docker_image: fastrpc-image:latest

--- a/.github/workflows/sync_build.yml
+++ b/.github/workflows/sync_build.yml
@@ -1,5 +1,10 @@
-name: Sync and build 
-description: sync and builds fastrpc code for a specified machine using a Docker image
+name: Sync and build
+description: |
+  This reusable workflow syncs and builds FastRPC code for a specified machine and firmware 
+  using a Docker image. It performs code checkout, Docker image build, workspace sync, 
+  kernel compilation, and artifact packaging. Key build outputs (Image, ramdisk, modules, DTB) 
+  are uploaded to S3, and the runner workspace is cleaned to manage disk usage. A summary of 
+  the build status is added to the GitHub Actions summary.
 
 on:
   workflow_call:
@@ -31,20 +36,20 @@ jobs:
           fetch-depth: 1
 
       - name: Build fastrpc docker image
-        uses: qualcomm/fastrpc/.github/actions/build_docker_image@main
+        uses: qualcomm/fastrpc/.github/actions/build_docker_image@development
         with:
           image: ${{ inputs.docker_image }}
 
       - name: Sync codebase
         id: sync
-        uses: qualcomm/fastrpc/.github/actions/sync@main
+        uses: qualcomm/fastrpc/.github/actions/sync@development
         with:
           machine: ${{ inputs.machine }}
           firmware: ${{ inputs.firmware }}
 
       - name: Build workspace
         id: build_workspace
-        uses: qualcomm/fastrpc/.github/actions/build@main
+        uses: qualcomm/fastrpc/.github/actions/build@development
         with:
           docker_image: ${{ inputs.docker_image }}
           workspace_path: ${{ steps.sync.outputs.workspace_path }}
@@ -70,7 +75,7 @@ jobs:
           cat "$workspace/artifacts/file_list.txt"
 
       - name: Upload artifacts
-        uses: qualcomm/fastrpc/.github/actions/aws_s3_helper@main
+        uses: qualcomm/fastrpc/.github/actions/aws_s3_helper@development
         with:
           s3_bucket: qli-prd-fastrpc-gh-artifacts
           # local_file points to the list of files to upload

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,4 @@
 name: test
-
 description: |
   Run tests on LAVA for a specified machine using a Docker image.
   This reusable GitHub Actions workflow executes FastRPC tests on LAVA infrastructure.
@@ -45,7 +44,7 @@ jobs:
           fetch-depth: 0
 
       - name: Build fastrpc docker image
-        uses: qualcomm/fastrpc/.github/actions/build_docker_image@main
+        uses: qualcomm/fastrpc/.github/actions/build_docker_image@development
         with:
           image: ${{ inputs.docker_image }}
 
@@ -78,7 +77,7 @@ jobs:
             core.setOutput("LAVANAME", lavaname);
 
       - name: Create fastrpc - lava job definition
-        uses: qualcomm/fastrpc/.github/actions/lava_job_render@main
+        uses: qualcomm/fastrpc/.github/actions/lava_job_render@development
         id: create_job_definition
         with:
           docker_image: ${{ inputs.docker_image }}


### PR DESCRIPTION
This PR introduces several improvements and bug fixes to the ramdisk preparation and matrix generation logic:

- Ensures CI uses the latest logic from the development branch.
- Adds proper descriptions for pre_merge and sync_build YAML files.
- Adds missing test folders to usr/bin and usr/lib.
- Archives only the contents of ramdisk_fastrpc using cpio -o -H newc from within the directory, excluding the top-level folder.
- Creates ramdisk_test directory before decompressing ramdisk_fastrpc.gz to avoid missing path errors.
- Fixes script syntax by converting comment style from # to // in action.yml loading logic.