### PR TITLE
Add IDL files

### DIFF
--- a/idl/AEEStdDef.idl
+++ b/idl/AEEStdDef.idl
@@ -1,0 +1,65 @@
+#ifndef AEESTDDEF_IDL
+#define AEESTDDEF_IDL
+//============================================================================
+/// @file AEEStdDef.idl
+///
+/// This file contains definitions of primitive  types.
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+//============================================================================
+
+/* NOTE: THIS FILE SHOULD NEVER BE COMPILED DIRECTLY.  That is, code should
+ * never be generated from these definitions, as they will conflict with the
+ * "real" hand-written AEEStdDef.h.  Note also that if the definitions here
+ * become out of sync with the hand-written AEEStdDef.h, bad things will
+ * happen.
+ */
+
+/**
+ * @name Primitive Types
+ */
+/*@{*/
+
+
+typedef octet              byte;        ///< Alternate alias for an unsigned
+                                        ///< 8-bit integer
+/*@}*/
+
+/**
+ * @name Types
+ */
+/*@{*/
+
+/** 
+ * This is a unique ID type.  Used to express types,
+ * interfaces, classes, and privileges.  The class ID generator generates
+ * unique IDs that can be used anywhere a new #AEEIID, #AEECLSID, or
+ * #AEEPRIVID is needed.
+ */
+typedef uint32             AEEUID;
+
+/**
+ * This is an interface ID type, used to denote an interface.  It is a special
+ case of #AEEUID.
+ */
+typedef uint32             AEEIID;
+
+/**
+ * This is a class ID type, used to denote a class.  It is  a special case of
+ #AEEUID.
+ */
+typedef uint32             AEECLSID;
+
+/**
+ * This is a privilege ID type, used to express a privilege.  It is a special
+ * case of #AEEUID.
+ */
+typedef uint32             AEEPRIVID;
+
+typedef wchar              AECHAR;      ///< Wide character type
+
+typedef long               AEEResult;   ///< Common return type
+
+/*@}*/
+
+#endif /* #ifndef AEESTDDEF_IDL */

--- a/idl/AEEStdErr.idl
+++ b/idl/AEEStdErr.idl
@@ -1,0 +1,95 @@
+#ifndef AEESTDERR_IDL
+#define AEESTDERR_IDL
+//============================================================================
+/// @file AEEStdErr.idl
+///
+/// This file contains error codes.
+                                                           //qidl copyright
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+//============================================================================
+
+#include "AEEStdDef.idl"
+
+/** @name Error Codes
+ * Common error codes.
+ */
+/*@{*/
+
+const AEEResult AEE_SUCCESS            = 0;  ///< No error
+const AEEResult AEE_EFAILED            = 1;  ///< General failure
+const AEEResult AEE_ENOMEMORY          = 2;  ///< Insufficient RAM
+const AEEResult AEE_ECLASSNOTSUPPORT   = 3;  ///< Specified class unsupported
+const AEEResult AEE_EVERSIONNOTSUPPORT = 4;  ///< Version not supported
+const AEEResult AEE_EALREADYLOADED     = 5;  ///< Object already loaded
+const AEEResult AEE_EUNABLETOLOAD      = 6;  ///< Unable to load object/applet
+const AEEResult AEE_EUNABLETOUNLOAD    = 7;  ///< Unable to unload 
+                                             ///< object/applet
+const AEEResult AEE_EALARMPENDING      = 8;  ///< Alarm is pending
+const AEEResult AEE_EINVALIDTIME       = 9;  ///< Invalid time
+const AEEResult AEE_EBADCLASS          = 10; ///< NULL class object
+const AEEResult AEE_EBADMETRIC         = 11; ///< Invalid metric specified
+const AEEResult AEE_EEXPIRED           = 12; ///< App/Component Expired
+const AEEResult AEE_EBADSTATE          = 13; ///< Invalid state
+const AEEResult AEE_EBADPARM           = 14; ///< Invalid parameter
+const AEEResult AEE_ESCHEMENOTSUPPORTED= 15; ///< Invalid URL scheme
+const AEEResult AEE_EBADITEM           = 16; ///< Invalid item
+const AEEResult AEE_EINVALIDFORMAT     = 17; ///< Invalid format
+const AEEResult AEE_EINCOMPLETEITEM    = 18; ///< Incomplete item
+const AEEResult AEE_ENOPERSISTMEMORY   = 19; ///< Insufficient flash
+const AEEResult AEE_EUNSUPPORTED       = 20; ///< API is not supported
+const AEEResult AEE_EPRIVLEVEL         = 21; ///< Privileges are insufficient
+                                             ///< for this operation
+const AEEResult AEE_ERESOURCENOTFOUND  = 22; ///< Unable to find specified
+                                             ///< resource
+const AEEResult AEE_EREENTERED         = 23; ///< Non re-entrant API 
+                                             ///< re-entered
+const AEEResult AEE_EBADTASK           = 24; ///< API called in wrong task
+                                             ///< context
+const AEEResult AEE_EALLOCATED         = 25; ///< App/Module left memory
+                                             ///< allocated when released.
+const AEEResult AEE_EALREADY           = 26; ///< Operation is already in
+                                             ///< progress
+const AEEResult AEE_EADSAUTHBAD        = 27; ///< ADS mutual authorization 
+                                             ///< failed
+const AEEResult AEE_ENEEDSERVICEPROG   = 28; ///< Need service programming
+const AEEResult AEE_EMEMPTR            = 29; ///< bad memory pointer
+const AEEResult AEE_EHEAP              = 30; ///< heap corruption
+const AEEResult AEE_EIDLE              = 31; ///< Context (system, interface,
+                                             ///< etc.) is idle
+const AEEResult AEE_EITEMBUSY          = 32; ///< Context (system, interface,
+                                             ///< etc.) is busy
+const AEEResult AEE_EBADSID            = 33; ///< Invalid subscriber ID
+const AEEResult AEE_ENOTYPE            = 34; ///< No type detected/found
+const AEEResult AEE_ENEEDMORE          = 35; ///< Need more data/info
+const AEEResult AEE_EADSCAPS           = 36; ///< ADS Capabilities do not
+                                             ///< match those required for
+                                             ///< phone
+const AEEResult AEE_EBADSHUTDOWN       = 37; ///< App failed to close properly
+const AEEResult AEE_EBUFFERTOOSMALL    = 38; ///< Destination buffer given is
+                                             ///< too small
+const AEEResult AEE_ENOSUCH            = 39; ///< No such name, port, socket
+                                             ///< or service exists or is 
+                                             ///< valid
+const AEEResult AEE_EACKPENDING        = 40; ///< ACK pending on application
+const AEEResult AEE_ENOTOWNER          = 41; ///< Not an owner authorized to
+                                             ///< perform the operation
+const AEEResult AEE_EINVALIDITEM       = 42; ///< Current item is invalid
+const AEEResult AEE_ENOTALLOWED        = 43; ///< Not allowed to perform the
+                                             ///< operation
+const AEEResult AEE_EINVHANDLE         = 44; ///< Invalid handle 
+const AEEResult AEE_EOUTOFHANDLES      = 45; ///< Out of handles
+const AEEResult AEE_EINTERRUPTED       = 46; ///< Waitable call is interrupted
+const AEEResult AEE_ENOMORE            = 47; ///< No more items available --
+                                             ///< reached end
+const AEEResult AEE_ECPUEXCEPTION      = 48; ///< A CPU exception occurred
+const AEEResult AEE_EREADONLY          = 49; ///< Cannot change read-only
+                                             ///< object or parameter
+const AEEResult AEE_ECONNRESET         =104; ///< Connection reset by peer
+const AEEResult AEE_EWOULDBLOCK        =516; ///< Operation would block if not
+                                             ///< non-blocking; wait and try
+                                             ///< again
+
+/*@}*/
+
+#endif /* #ifndef AEESTDERR_IDL */

--- a/idl/adsp_current_process.idl
+++ b/idl/adsp_current_process.idl
@@ -1,0 +1,17 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+module adsp {
+
+   interface current_process {
+      long exit();
+      long thread_exit();
+      long set_logging_params(in unsigned short mask, in sequence<string> filesToLog);
+      long getASID(rout unsigned long asid);
+      long setQoS(in unsigned long latency);
+      long exception();
+      long set_logging_params2(in unsigned long mask, in sequence<string> filesToLog);
+      long poll_mode(in unsigned long enable, in unsigned long timeout);
+      long enable_notifications();
+   };
+};
+

--- a/idl/adsp_current_process1.idl
+++ b/idl/adsp_current_process1.idl
@@ -1,0 +1,22 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+#include "remote.idl"
+
+const long _const_adsp_current_process1_handle = 4;
+
+module adsp {
+   interface current_process1 : remote_handle64 {
+      long exit();
+      long thread_exit();
+      long set_logging_params(in unsigned short mask, in sequence<string> filesToLog);
+      long getASID(rout unsigned long asid);
+      long setQoS(in unsigned long latency);
+      long exception();
+      long set_logging_params2(in unsigned long mask, in sequence<string> filesToLog);
+      long poll_mode(in unsigned long enable, in unsigned long timeout);
+      long enable_notifications();
+      long panic_err_codes(in sequence<long> err_codes);
+      long exception_with_param(in string crash_info);
+   };
+};
+

--- a/idl/adsp_default_listener.idl
+++ b/idl/adsp_default_listener.idl
@@ -1,0 +1,7 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+module adsp {
+   interface default_listener {
+      long register();
+   };
+};

--- a/idl/adsp_default_listener1.idl
+++ b/idl/adsp_default_listener1.idl
@@ -1,0 +1,12 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+/* This IDL is needed to support domains usecases of FastRPC daemons.
+   This file is same as adsp_default_listener.idl but with domains support */
+
+#include "remote.idl"
+
+module adsp  {
+   interface default_listener1 : remote_handle64{
+      long register();
+   };
+};

--- a/idl/adsp_listener.idl
+++ b/idl/adsp_listener.idl
@@ -1,0 +1,43 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+#include "AEEStdDef.idl"
+
+const long _const_adsp_listener_handle = 3;
+
+module adsp {
+   interface listener {
+      typedef sequence<uint8> buffer;
+      typedef uint32 remote_handle;
+      typedef uint32 invoke_ctx;
+      /* these methods are deprecated
+       */
+      long next_invoke(in invoke_ctx prevCtx,
+                       in long prevResult, 
+                       in sequence<buffer> outBufs, 
+                       rout invoke_ctx ctx,
+                       rout remote_handle handle, 
+                       rout uint32 sc,
+                       rout sequence<buffer> inBuffers, 
+                       rout sequence<long> inBufLenReq,
+                       rout sequence<long> routBufLenReq);
+      long invoke_get_in_bufs(in invoke_ctx ctx,
+                              rout sequence<buffer> inBuffers);
+      long init();
+      /* 
+       * v2, simpler faster methods
+       */
+      long init2();
+      long next2(in invoke_ctx prevCtx, 
+                 in long prevResult, 
+                 in sequence<uint8> prevbufs,
+                 rout invoke_ctx ctx,
+                 rout remote_handle handle, 
+                 rout uint32 sc,
+                 rout sequence<uint8> bufs,
+                 rout long bufsLenReq);
+      long get_in_bufs2(in invoke_ctx ctx, 
+                        in long offset,
+                        rout sequence<uint8> bufs, 
+                        rout long bufsLenReq);
+   };
+};

--- a/idl/adsp_listener1.idl
+++ b/idl/adsp_listener1.idl
@@ -1,0 +1,44 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+#include "remote.idl"
+#include "AEEStdDef.idl"
+
+const long _const_adsp_listener1_handle = 7;
+
+module adsp {
+   interface listener1 : remote_handle64 {
+      typedef sequence<uint8> buffer;
+      typedef uint32 remote_handle;
+      typedef uint32 invoke_ctx;
+      /* these methods are deprecated
+       */
+      long next_invoke(in invoke_ctx prevCtx,
+                       in long prevResult, 
+                       in sequence<buffer> outBufs, 
+                       rout invoke_ctx ctx,
+                       rout remote_handle handle, 
+                       rout uint32 sc,
+                       rout sequence<buffer> inBuffers, 
+                       rout sequence<long> inBufLenReq,
+                       rout sequence<long> routBufLenReq);
+      long invoke_get_in_bufs(in invoke_ctx ctx,
+                              rout sequence<buffer> inBuffers);
+      long init();
+      /* 
+       * v2, simpler faster methods
+       */
+      long init2();
+      long next2(in invoke_ctx prevCtx, 
+                 in long prevResult, 
+                 in sequence<uint8> prevbufs,
+                 rout invoke_ctx ctx,
+                 rout remote_handle handle, 
+                 rout uint32 sc,
+                 rout sequence<uint8> bufs,
+                 rout long bufsLenReq);
+      long get_in_bufs2(in invoke_ctx ctx, 
+                        in long offset,
+                        rout sequence<uint8> bufs, 
+                        rout long bufsLenReq);
+   };
+};

--- a/idl/adsp_perf.idl
+++ b/idl/adsp_perf.idl
@@ -1,0 +1,53 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+#include "AEEStdDef.idl"
+
+/**
+ * Interface for querying the adsp for counter data
+ * For example, to enable all the perf numbers:
+ * 
+ *     int perf_on(void) {
+ *       int nErr = 0;
+ *       int numKeys = 0, maxLen = 0, ii;
+ *       char keys[512];
+ *       char* buf = &keys[0];
+ *       VERIFY(0 == adsp_perf_get_keys(keys, 512, &maxLen, &numKeys)); 
+ *       assert(maxLen < 512);
+ *       for(ii = 0; ii < numKeys; ++ii) {
+ *          char* name = buf;
+ *          buf += strlen(name) + 1;
+ *          printf("perf on: %s\n", name);
+ *          VERIFY(0 == adsp_perf_enable(ii));
+ *       }
+ *    bail:
+ *       return nErr;
+ *    }
+ *
+ * To read all the results:
+ *
+ *    int rpcperf_perf_result(void) {
+ *       int nErr = 0;
+ *       int numKeys, maxLen, ii;
+ *       char keys[512];
+ *       char* buf = &keys[0];
+ *       long long usecs[16];
+ *       VERIFY(0 == adsp_perf_get_keys(keys, 512, &maxLen, &numKeys)); 
+ *       printf("perf keys: %d\n", numKeys);
+ *       VERIFY(0 == adsp_perf_get_usecs(usecs, 16));
+ *       assert(maxLen < 512);
+ *       assert(numKeys < 16);
+ *       for(ii = 0; ii < numKeys; ++ii) {
+ *          char* name = buf;
+ *          buf += strlen(name) + 1;
+ *          printf("perf result: %s %lld\n", name, usecs[ii]);
+ *       }
+ *    bail:
+ *       return nErr;
+ *    }
+ */
+const long _const_adsp_perf_handle = 6;
+interface adsp_perf {
+   long enable(in long ix);
+   long get_usecs(rout sequence<long long> dst);
+   long get_keys(rout sequence<char> keys, rout long maxLen, rout long numKeys);
+};

--- a/idl/adsp_perf1.idl
+++ b/idl/adsp_perf1.idl
@@ -1,0 +1,59 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+#ifndef ADSP_PERF1_IDL
+#define ADSP_PERF1_IDL
+
+#include "remote.idl"
+#include "AEEStdDef.idl"
+
+/**
+ * Interface for querying the adsp for counter data
+ * For example, to enable all the perf numbers:
+ * 
+ *     int perf_on(void) {
+ *       int nErr = 0;
+ *       int numKeys = 0, maxLen = 0, ii;
+ *       char keys[512];
+ *       char* buf = &keys[0];
+ *       VERIFY(0 == adsp_perf_get_keys(keys, 512, &maxLen, &numKeys)); 
+ *       assert(maxLen < 512);
+ *       for(ii = 0; ii < numKeys; ++ii) {
+ *          char* name = buf;
+ *          buf += strlen(name) + 1;
+ *          printf("perf on: %s\n", name);
+ *          VERIFY(0 == adsp_perf_enable(ii));
+ *       }
+ *    bail:
+ *       return nErr;
+ *    }
+ *
+ * To read all the results:
+ *
+ *    int rpcperf_perf_result(void) {
+ *       int nErr = 0;
+ *       int numKeys, maxLen, ii;
+ *       char keys[512];
+ *       char* buf = &keys[0];
+ *       long long usecs[16];
+ *       VERIFY(0 == adsp_perf_get_keys(keys, 512, &maxLen, &numKeys)); 
+ *       printf("perf keys: %d\n", numKeys);
+ *       VERIFY(0 == adsp_perf_get_usecs(usecs, 16));
+ *       assert(maxLen < 512);
+ *       assert(numKeys < 16);
+ *       for(ii = 0; ii < numKeys; ++ii) {
+ *          char* name = buf;
+ *          buf += strlen(name) + 1;
+ *          printf("perf result: %s %lld\n", name, usecs[ii]);
+ *       }
+ *    bail:
+ *       return nErr;
+ *    }
+ */
+const long _const_adsp_perf1_handle = 9;
+interface adsp_perf1 : remote_handle64 {
+   long enable(in long ix);
+   long get_usecs(rout sequence<long long> dst);
+   long get_keys(rout sequence<char> keys, rout long maxLen, rout long numKeys);
+};
+
+#endif

--- a/idl/adspmsgd_adsp.idl
+++ b/idl/adspmsgd_adsp.idl
@@ -1,0 +1,11 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+#include "AEEStdDef.idl"
+
+// Interface used by APPS to initialize the adspmsgd service on the ADSP (forward invoke)
+interface adspmsgd_adsp {
+    long init(in long heapid, in uint32 ion_flags, in uint32 filter, in uint32 buf_size, rout long buff_addr);
+    long init2();
+    long deinit();
+};
+

--- a/idl/adspmsgd_adsp1.idl
+++ b/idl/adspmsgd_adsp1.idl
@@ -1,0 +1,15 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+#include "AEEStdDef.idl"
+#include "remote.idl"
+
+const long _const_adspmsgd_adsp1_handle = 5;
+
+// Interface used by APPS to initialize the adspmsgd service on the ADSP (forward invoke)
+interface adspmsgd_adsp1 : remote_handle64 {
+    long init2();
+    long deinit();
+//	To enable adspmsgd with shared memory implementation
+	long init3(in long heapid, in uint32 ion_flags, in uint32 filter, in uint64 buf_size, rout uint64 buff_addr);
+	long wait(rout uint64 bytes_to_read);
+};

--- a/idl/adspmsgd_apps.idl
+++ b/idl/adspmsgd_apps.idl
@@ -1,0 +1,18 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+#include "AEEStdDef.idl"
+
+// Interface used by the ADSP to send log messages back to the APPS (reverse invoke)
+interface adspmsgd_apps {
+    enum Level{
+        LOW,
+        MEDIUM,
+        HIGH,
+        ERROR,
+        FATAL
+    };
+
+    typedef sequence <octet> octetSeq;
+
+    long log(in octetSeq log_message_buffer);
+};

--- a/idl/apps_mem.idl
+++ b/idl/apps_mem.idl
@@ -1,0 +1,17 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+#include "AEEStdDef.idl"
+
+module apps {
+   interface mem {
+      long request_map(in long heapid, in uint32 ion_flags, in uint32 rflags, in uint32 vin, in int32 len, rout uint32 vapps, rout uint32 vadsp);
+      long request_unmap(in uint32 vadsp, in int32 len);
+      long request_map64(in long heapid, in uint32 ion_flags, in uint32 rflags, in uint64 vin, in int64 len, rout uint64 vapps, rout uint64 vadsp);
+      long request_unmap64(in uint64 vadsp, in int64 len);
+      long share_map(in long fd, in long size, rout uint64 vapps, rout uint64 vadsp);
+      long share_unmap(in uint64 vadsp, in long size);
+      long dma_handle_map(in long fd, in long offset, in long size);
+      long dma_handle_unmap(in long fd, in long size);
+   };
+};
+

--- a/idl/apps_remotectl.idl
+++ b/idl/apps_remotectl.idl
@@ -1,0 +1,7 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+#include "AEEStdDef.idl"
+interface apps_remotectl {
+	 long open(in string name, rout long handle, rout sequence<char> dlerror, rout long nErr);
+	 long close(in long handle, rout sequence<char> dlerror, rout long nErr);
+};

--- a/idl/apps_std.idl
+++ b/idl/apps_std.idl
@@ -1,0 +1,202 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+#include "AEEStdDef.idl"
+
+module apps {
+   /**
+    * standard library functions remoted from the apps to the dsp
+    */
+   interface std {
+
+      typedef long FILE;
+      enum SEEK {
+         APPS_STD_SEEK_SET,
+         APPS_STD_SEEK_CUR,
+         APPS_STD_SEEK_END
+      };
+
+      struct DIR {
+         uint64 handle;
+      };
+
+      struct DIRENT {
+         long ino;
+         char name[255];
+      };
+
+      struct STAT {
+         uint64 tsz;
+         uint64 dev;
+         uint64 ino;
+         uint32 mode;
+         uint32 nlink;
+         uint64 rdev;
+         uint64 size;
+         int64 atime;
+         int64 atimensec;
+         int64 mtime;
+         int64 mtimensec;
+         int64 ctime;
+         int64 ctimensec;
+      };
+   
+      /**
+       * @retval, if operation fails errno is returned
+       */
+      long fopen(in string name, in string mode, rout FILE psout);
+      long freopen(in FILE sin, in string name, in string mode, rout FILE psout);
+      long fflush(in FILE sin);
+      long fclose(in FILE sin);
+
+      /**
+       * @param,  bEOF, if read or write bytes <= bufLen bytes then feof() is called
+       *          and the result is returned in bEOF, otherwise bEOF is set to 0.
+       * @retval, if read or write return 0 for non zero length buffers, ferror is checked
+       *          and a non zero value is returned in case of error with no rout parameters
+       */
+      long fread(in FILE sin, rout sequence<byte> buf, rout long bytesRead, rout long bEOF);
+      long fwrite(in FILE sin, in sequence<byte> buf, rout long bytesWritten, rout long bEOF);
+
+      /**
+       * @param, pos, this buffer is filled up to MIN(posLen, sizeof(fpos_t))
+       * @param, posLenReq, returns sizeof(fpos_t)
+       * @retval, if operation fails errno is returned
+       */
+      long fgetpos(in FILE sin, rout sequence<byte> pos, rout long posLenReq);
+
+      /**
+       * @param, if size of pos doesn't match the system size an error is returned.
+       *         fgetpos can be used to query the size of fpos_t
+       * @retval, if operation fails errno is returned
+       */
+      long fsetpos(in FILE sin, in sequence<byte> pos);
+
+      /**
+       * @retval, if operation fails errno is returned
+       */
+      long ftell(in FILE sin, rout long pos);
+      long fseek(in FILE sin, in long offset, in SEEK whence);
+      long flen(in FILE sin, rout uint64 len);
+
+      /**
+       * @retval, only fails if transport fails
+       */
+      long rewind(in FILE sin);
+      long feof(in FILE sin, rout long bEOF);
+      long ferror(in FILE sin, rout long err);
+      long clearerr(in FILE sin);
+      long print_string(in string str);
+
+      /**
+       * @param val, must contain space for NULL
+       * @param valLenReq, length required with NULL
+       * @retval, if fails errno is returned
+       */
+      long getenv(in string name, rout string val, rout long valLenReq);
+
+      /**
+       * @retval, if fails errno is returned
+       */
+      long setenv(in string name, in string val, in long override);
+      long unsetenv(in string name);
+      /**
+       * This function will try to open a file given directories in envvarname separated by
+       * delim.
+       * so given environment variable FOO_PATH=/foo;/bar
+       *    fopen_wth_env("FOO_PATH", ";", "path/to/file", "rw", &out);
+       * will try to open /foo/path/to/file, /bar/path/to/file
+       * if the variable is unset, it will open the file directly
+       *
+       * @param envvarname, name of the environment variable containing the path
+       * @param delim, delimiator string, such as ";"
+       * @param name, name of the file
+       * @param mode, mode
+       * @param psout, output handle
+       * @retval, 0 on success errno or -1 on failure
+       */
+      long fopen_with_env(in string envvarname, in string delim, in string name, in string mode, rout FILE psout);
+      long fgets(in FILE sin, rout sequence<byte> buf, rout long bEOF);
+
+      /**
+       * This method will return the paths that are searched when looking for a file.
+       *  The paths are defined by the environment variable (separated by delimiters)
+       *  that is passed to the method.
+       *
+       * @param envvarname, name of the environment variable containing the path
+       * @param delim, delimiator string, such as ";"
+       * @param name, name of the file
+       * @param paths, Search paths
+       * @param numPaths, Actual number of paths found
+       * @param maxPathLen, The max path length
+       * @retval, 0 on success errno or -1 on failure
+       *
+       */
+       long get_search_paths_with_env(in string envvarname, in string delim,
+            rout sequence<string> paths, rout uint32 numPaths, rout uint16 maxPathLen);
+
+       long fileExists(in string path, rout boolean exists);
+       long fsync(in FILE sin);
+       long fremove(in string name);
+
+       /**
+        * This function decrypts the file using the provided open file descriptor, closes the
+        * original descriptor and return a new file descriptor.
+        * @retval, if operation fails errno is returned
+        */
+       long fdopen_decrypt(in FILE sin, rout FILE psout);
+
+       long opendir(in string name, rout DIR dir);
+       long closedir(in DIR dir);
+       long readdir(in DIR dir, rout DIRENT dirent, rout long bEOF);
+       long mkdir(in string name, in long mode);
+       long rmdir(in string name);
+       long stat(in string name, rout STAT stat);
+
+       /* 
+       * This method will truncate the size of the file to offset
+       * 
+       * @param sin, file stream as input
+       * @param offset is the size of the file
+       * @retval 0 on success errno or -1 on failure
+       */
+       long ftrunc(in FILE sin, in long offset);
+       long frename(in string oldname, in string newname);
+       /**
+       * This function will try to open a file with provided mode
+       * and return fd to this file.
+       *
+       * @param name, name of the file
+       * @param mode, mode
+       * @param fd, output file fd
+       * @param len, output file fd len
+       * @retval, 0 on success errno or -1 on failure
+       */
+       long fopen_fd(in string name, in string mode, rout long fd, rout long len);
+
+       /**
+       * This function will try to close fd and the file opened by this fd 
+       *
+       * @param fd, fd to file
+       * @retval, 0 on success errno or -1 on failure
+       */
+       long fclose_fd(in long fd);
+
+       /**
+       * This function will try to open a file given directories in envvarname separated by
+       * delim.
+       * so given environment variable FOO_PATH=/foo;/bar
+       *    fopen_wth_env("FOO_PATH", ";", "path/to/file", "rw", &out);
+       * will try to open /foo/path/to/file, /bar/path/to/file
+       * if the variable is unset, it will open the file directly and return fd to that file
+       *
+       * @param envvarname, name of the environment variable containing the path
+       * @param delim, delimiator string, such as ";"
+       * @param name, name of the file
+       * @param mode, mode
+       * @param fd, output file fd
+       * @param len, output file fd len
+       * @retval, 0 on success errno or -1 on failure
+       */
+       long fopen_with_env_fd(in string envvarname, in string delim, in string name, in string mode, rout long fd, rout long len);
+   };
+};

--- a/idl/dspqueue_rpc.idl
+++ b/idl/dspqueue_rpc.idl
@@ -1,0 +1,47 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
+#ifndef DSPQUEUE_RPC_IDL
+#define DSPQUEUE_RPC_IDL
+
+#include "AEEStdDef.idl"
+#include "remote.idl"
+
+/* Internal RPC interface used for Asynchronous DSP Packet Queue
+ * implementation. Used to create, destroy and manage queues, and to
+ * send and receive signals between the CPU and the DSP. The interface
+ * is implemented statically in the FastRPC shell, and used by the
+ * queue implementation linked to lib?dsprpc.so on the CPU side.
+ */
+
+interface dspqueue_rpc : remote_handle64 {
+    AEEResult init_process_state(
+        in int32 process_state_fd
+        );
+
+    AEEResult create_queue(
+        in uint32 id,
+        in int32 queue_fd,
+        in uint32 count,
+        rout uint64 queue_id
+        );
+
+    AEEResult destroy_queue(
+        in uint64 queue_id
+        );
+
+    AEEResult is_imported (
+        in uint64 queue_id,
+        rout int32 imported
+        );
+
+    AEEResult wait_signal(
+        rout int32 signal
+        );
+
+    AEEResult cancel_wait_signal();
+
+    AEEResult signal();
+};
+
+#endif //DSPQUEUE_RPC_IDL

--- a/idl/remote.idl
+++ b/idl/remote.idl
@@ -1,0 +1,34 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+interface remote_handle64 {
+   /**
+    * Opens the handle in the specified domain.  If this is the first
+    * handle, this creates the session.  Typically this means opening
+    * the device, aka open("/dev/adsprpc-smd"), then calling ioctl
+    * device APIs to create a PD on the DSP to execute our code in,
+    * then asking that PD to dlopen the .so and dlsym the skel function.
+    *
+    * @param uri, <interface>_URI"&_dom=aDSP"
+    *    <interface>_URI is a QAIC generated uri, or
+    *    "file:///<sofilename>?<interface>_skel_handle_invoke&_modver=1.0"
+    *    If the _dom parameter is not present, _dom=DEFAULT is assumed
+    *    but not forwarded.
+    *    Reserved uri keys:
+    *      [0]: first unamed argument is the skel invoke function
+    *      _dom: execution domain name, _dom=mDSP/aDSP/DEFAULT
+    *      _modver: module version, _modver=1.0
+    *      _*: any other key name starting with an _ is reserved
+    *    Unknown uri keys/values are forwarded as is.
+    * @param h, resulting handle
+    * @retval, 0 on success
+    */
+   long open(in string uri, rout remote_handle64 h);
+   /** 
+    * Closes a handle.  If this is the last handle to close, the session
+    * is closed as well, releasing all the allocated resources.
+
+    * @param h, the handle to close
+    * @retval, 0 on success, should always succeed
+    */
+   long close(in remote_handle64 h);
+};

--- a/idl/remotectl.idl
+++ b/idl/remotectl.idl
@@ -1,0 +1,12 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+#include "AEEStdDef.idl"
+
+const long _const_remotectl_handle = 0;
+
+interface remotectl {
+	 long open(in string name, rout long handle, rout sequence<char> dlerror, rout long nErr);
+	 long close(in long handle, rout sequence<char> dlerror, rout long nErr);
+	 long grow_heap(in uint32 phyAddr, in uint32 nSize);
+	 long set_param(in long reqID, in sequence<uint32> params);
+};

--- a/idl/remotectl1.idl
+++ b/idl/remotectl1.idl
@@ -1,0 +1,18 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+#ifndef REMOTECTL1_IDL
+#define REMOTECTL1_IDL
+
+#include "remote.idl"
+#include "AEEStdDef.idl"
+
+const long _const_remotectl1_handle = 8;
+
+interface remotectl1 : remote_handle64 {
+	 long open1(in string name, rout long handle, rout sequence<char> dlerror, rout long nErr);
+	 long close1(in long handle, rout sequence<char> dlerror, rout long nErr);
+	 long grow_heap(in uint32 phyAddr, in uint32 nSize);
+	 long set_param(in long reqID, in sequence<uint32> params);
+};
+
+#endif


### PR DESCRIPTION
This change includes adding necessary IDL files to fastrpc/idl. These IDL files are compiled by QAIC to generate their
corresponding header, stub, and skel C files. This is only for reference for the time-being. The files are currently not being used.

CRs-Fixed: 4624176