### PR TITLE
fastrpc: fix use-after-free in close_domain_session during session teardown

### DIFF
--- a/src/fastrpc_apps_user.c
+++ b/src/fastrpc_apps_user.c
@@ -2353,7 +2353,7 @@ bail:
 }
 
 static int close_domain_session(int domain) {
-  QNode *pn = NULL, *pnn = NULL;
+  QNode *pn = NULL;
   char dlerrstr[255];
   int dlerr = 0, nErr = AEE_SUCCESS, mut_locked = 0;
   remote_handle64 proc_handle = 0;
@@ -2370,38 +2370,41 @@ static int close_domain_session(int domain) {
   }
   pthread_mutex_lock(&hlist[domain].lmut);
   mut_locked = 1;
-  if (!QList_IsEmpty(&hlist[domain].nql)) {
-    QLIST_NEXTSAFE_FOR_ALL(&hlist[domain].nql, pn, pnn) {
-      struct handle_info *hi = STD_RECOVER_REC(struct handle_info, qn, pn);
-      VERIFYC(NULL != hi, AEE_EINVHANDLE);
-      pthread_mutex_unlock(&hlist[domain].lmut);
-      mut_locked = 0;
-      remote_handle_close(hi->remote);
-      pthread_mutex_lock(&hlist[domain].lmut);
-      mut_locked = 1;
-    }
+
+  while (!QList_IsEmpty(&hlist[domain].nql)) {
+    struct handle_info *hi;
+    pn = QList_Pop(&hlist[domain].nql);
+    hi = STD_RECOVER_REC(struct handle_info, qn, pn);
+    VERIFYC(NULL != hi, AEE_EINVHANDLE);
+    pthread_mutex_unlock(&hlist[domain].lmut);
+    mut_locked = 0;
+    remote_handle_close(hi->remote);
+    pthread_mutex_lock(&hlist[domain].lmut);
+    mut_locked = 1;
   }
-  if (!QList_IsEmpty(&hlist[domain].rql)) {
-    QLIST_NEXTSAFE_FOR_ALL(&hlist[domain].rql, pn, pnn) {
-      struct handle_info *hi = STD_RECOVER_REC(struct handle_info, qn, pn);
-      VERIFYC(NULL != hi, AEE_EINVHANDLE);
-      pthread_mutex_unlock(&hlist[domain].lmut);
-      mut_locked = 0;
-      close_reverse_handle(hi->local, dlerrstr, sizeof(dlerrstr), &dlerr);
-      pthread_mutex_lock(&hlist[domain].lmut);
-      mut_locked = 1;
-    }
+
+  while (!QList_IsEmpty(&hlist[domain].rql)) {
+    struct handle_info *hi;
+    pn = QList_Pop(&hlist[domain].rql);
+    hi = STD_RECOVER_REC(struct handle_info, qn, pn);
+    VERIFYC(NULL != hi, AEE_EINVHANDLE);
+    pthread_mutex_unlock(&hlist[domain].lmut);
+    mut_locked = 0;
+    close_reverse_handle(hi->local, dlerrstr, sizeof(dlerrstr), &dlerr);
+    pthread_mutex_lock(&hlist[domain].lmut);
+    mut_locked = 1;
   }
-  if (!QList_IsEmpty(&hlist[domain].ql)) {
-    QLIST_NEXTSAFE_FOR_ALL(&hlist[domain].ql, pn, pnn) {
-      struct handle_info *hi = STD_RECOVER_REC(struct handle_info, qn, pn);
-      VERIFYC(NULL != hi, AEE_EINVHANDLE);
-      pthread_mutex_unlock(&hlist[domain].lmut);
-      mut_locked = 0;
-      remote_handle64_close(hi->local);
-      pthread_mutex_lock(&hlist[domain].lmut);
-      mut_locked = 1;
-    }
+
+  while (!QList_IsEmpty(&hlist[domain].ql)) {
+    struct handle_info *hi;
+    pn = QList_Pop(&hlist[domain].ql);
+    hi = STD_RECOVER_REC(struct handle_info, qn, pn);
+    VERIFYC(NULL != hi, AEE_EINVHANDLE);
+    pthread_mutex_unlock(&hlist[domain].lmut);
+    mut_locked = 0;
+    remote_handle64_close(hi->local);
+    pthread_mutex_lock(&hlist[domain].lmut);
+    mut_locked = 1;
   }
   pthread_mutex_unlock(&hlist[domain].lmut);
   mut_locked = 0;


### PR DESCRIPTION
close_domain_session() iterated over the per-domain handle lists (nql, rql and ql) using QLIST_NEXTSAFE_FOR_ALL, which caches the next node (pnn) up front. Inside the loop body the list mutex is dropped to issue the remote close:

    pthread_mutex_unlock(&hlist[domain].lmut);
    remote_handle64_close(hi->local);
    pthread_mutex_lock(&hlist[domain].lmut);

NEXTSAFE only guarantees that freeing the current node (pn) is safe; it does not protect the cached next node (pnn) across the unlock window. While the lock is dropped, the cascaded cleanup inside the remote close path and the concurrently exiting listener thread can unlink and free the node pnn points to. On the next iteration pn = pnn dereferences a dangling pointer, leading to a use-after-free crash:

    close_domain_session
    remote_session_control (req=7, FASTRPC_SESSION_CLOSE)
    Program terminated with signal SIGSEGV
    pnn = 0xaaa1b7150f3d   /* poisoned next pointer */

This only reproduces on targets that support status notifications: the FASTRPC_SESSION_CLOSE path in the test app is gated by status_notif_capability, so targets without notification support never enter close_domain_session and are unaffected.

Replace the NEXTSAFE traversal with a pop-based loop that re-reads the list head under the lock on every iteration and unlinks the node with QList_Pop before dropping the mutex. The node is off the list before the remote close runs, so neither the close cascade nor the listener thread can free a node we still reference, eliminating the dangling next pointer. Apply the same fix to all three lists (nql, rql, ql).

CRs-Fixed: 4635710