### PR TITLE
files: Move inline comment out of RestartPreventExitStatus

### DIFF
--- a/files/adsprpcd_audiopd.service.in
+++ b/files/adsprpcd_audiopd.service.in
@@ -9,5 +9,6 @@ Type=exec
 ExecStart=@sbindir@/adsprpcd audiopd
 Restart=on-failure
 RestartSec=5
-RestartPreventExitStatus=2  # AEE_ENOMEMORY
+# AEE_ENOMEMORY
+RestartPreventExitStatus=2
 RestartForceExitStatus=SIGTERM


### PR DESCRIPTION
Systemd only treats a line as a comment when '#' (or ';') is the first non-whitespace character on that line; there is no support for trailing comments after a value. The "# AEE_ENOMEMORY" annotation added next to RestartPreventExitStatus=2 is therefore parsed as part of the value, and systemd-analyze verify reports:

  adsprpcd_audiopd.service: Failed to parse value, ignoring: #
  adsprpcd_audiopd.service: Failed to parse value, ignoring: AEE_ENOMEMORY

The exit status 2 itself is still applied, since unparsable words are skipped, but the warnings show up on every unit load.

Move the annotation to its own line above the directive.

Fixes: cd0c0dbbfef8 ("dsprpcd: fix daemon restart behavior for SIGTERM and ENOMEM")