### PR TITLE
fix(dsp_check): correct DSP module search scoping and honor --with-config-base-dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ src/adsprpcd
 src/cdsprpcd
 src/sdsprpcd
 src/gdsprpcd
+test/dsp_check
 test/fastrpc_test
 
 # make dist tarballs

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -33,7 +33,8 @@ endif
 dsp_check_SOURCES = dsp_check.c
 
 # Base compiler flags (always)
-dsp_check_CFLAGS = -I$(top_srcdir)/inc -DUSE_SYSLOG
+dsp_check_CFLAGS = -I$(top_srcdir)/inc -DUSE_SYSLOG \
+                   -DCONFIG_BASE_DIR='"$(CONFIG_BASE_DIR)"'
 
 if ANDROID_CC
 dsp_check_CFLAGS += -DANDROID

--- a/test/dsp_check.c
+++ b/test/dsp_check.c
@@ -27,7 +27,10 @@
 #define PATH_MAX 4096
 #endif
 
-#define QCOM_BASE_DIR "/usr/share/qcom"
+#ifndef CONFIG_BASE_DIR
+#define CONFIG_BASE_DIR "/usr/share/qcom/"
+#endif
+#define QCOM_BASE_DIR CONFIG_BASE_DIR
 #define MACHINE_MODEL_PATH "/sys/firmware/devicetree/base/model"
 
 #ifdef ANDROID
@@ -230,7 +233,11 @@ static char* find_dsp_library_path_from_yaml(void)
     if (read_text(MACHINE_MODEL_PATH, machine, sizeof(machine)) < 0)
         return NULL;
     machine[strcspn(machine, "\n")] = '\0';
-    DIR* dir = opendir("/usr/share/qcom/conf.d");
+
+    char conf_dir[PATH_MAX];
+    snprintf(conf_dir, sizeof(conf_dir), "%s/conf.d", QCOM_BASE_DIR);
+
+    DIR* dir = opendir(conf_dir);
     if (!dir)
         return NULL;
 
@@ -243,7 +250,7 @@ static char* find_dsp_library_path_from_yaml(void)
 
         char yaml_path[PATH_MAX];
         snprintf(yaml_path, sizeof(yaml_path),
-                 "/usr/share/qcom/conf.d/%s", de->d_name);
+                 "%s/%s", conf_dir, de->d_name);
 
         FILE* f = fopen(yaml_path, "r");
         if (!f)
@@ -887,7 +894,8 @@ static bool scan_qcom_yaml_and_check_dsp_modules(
         return false;
     }
 
-    const char* dirpath = "/usr/share/qcom/conf.d";
+    char dirpath[PATH_MAX];
+    snprintf(dirpath, sizeof(dirpath), "%s/conf.d", QCOM_BASE_DIR);
     DIR* dir = opendir(dirpath);
     if (!dir) {
         return false;

--- a/test/dsp_check.c
+++ b/test/dsp_check.c
@@ -723,20 +723,16 @@ static void build_search_for(dsp_t* d, const char* dsp_all_env, const char* yaml
     if (yaml_base_path) {
         char dsp_base[PATH_MAX];
         snprintf(dsp_base, sizeof(dsp_base), "%s/%s", QCOM_BASE_DIR, yaml_base_path);
-        if (is_dir(dsp_base)) {
-            DIR* dir = opendir(dsp_base);
-            if (dir) {
-                struct dirent* de;
-                while ((de = readdir(dir)) != NULL) {
-                    if (de->d_name[0] == '.') continue;
-                    char subdir[PATH_MAX];
-                    snprintf(subdir, sizeof(subdir), "%s/%s", dsp_base, de->d_name);
-                    if (is_dir(subdir)) {
-                        vec_push(&ordered, subdir);
-                    }
-                }
-                closedir(dir);
-            }
+
+        char dsp_lc[16];
+        snprintf(dsp_lc, sizeof(dsp_lc), "%s", d->name);
+        for (char* c = dsp_lc; *c; c++)
+            *c = (char)tolower((unsigned char)*c);
+
+        char subdir[PATH_MAX];
+        snprintf(subdir, sizeof(subdir), "%s/%s", dsp_base, dsp_lc);
+        if (is_dir(subdir)) {
+            vec_push(&ordered, subdir);
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes two correctness bugs in `test/dsp_check.c` that could cause the
tool to report incorrect FastRPC support status, plus a minor build
hygiene fix.

## Changes

### 1. Fix DSP module search path scoping (`build_search_for`)

`build_search_for()` enumerated **every** subdirectory under the
YAML-derived DSP library base path and added all of them to a DSP's
search list, instead of only adding the subdirectory matching that
specific DSP (e.g. `adsp/`, `cdsp/`, `sdsp/`). As a result, a DSP's
module search list could include other DSPs' library folders.

**Impact:** `dsp_check` could report `FastRPC Support: Yes` for a DSP
that doesn't actually have its own shell module installed, if another
DSP's folder happened to contain one.

**Fix:** Build the DSP-specific subdirectory path directly using the
DSP's own lower-cased name, consistent with the scoping already used
in `scan_yaml_shell_availability()` and `add_android_dsp_search_root()`.

### 2. Honor `--with-config-base-dir` instead of hardcoding `/usr/share/qcom`

`dsp_check.c` hardcoded `QCOM_BASE_DIR` as `/usr/share/qcom`, and two
functions additionally hardcoded the literal `/usr/share/qcom/conf.d`
path directly. This ignored the `--with-config-base-dir` configure
option already honored by the rest of the codebase (e.g.
`src/fastrpc_config_parser.c`'s `CONFIG_DIR`), which distros use to
relocate config files — for example, Debian's packaging passes
`--with-config-base-dir=/usr/share/hexagon-dsp`.

**Impact:** On such distros, `dsp_check` would keep looking under
`/usr/share/qcom/` and incorrectly report missing DSP modules/firmware
even though everything is correctly installed under the configured
path.

**Fix:**
- `test/dsp_check.c`: derive `QCOM_BASE_DIR` from the build-time
  `CONFIG_BASE_DIR` macro (falling back to `/usr/share/qcom/` if
  undefined), and build the `conf.d` path dynamically instead of
  hardcoding it twice.
- `test/Makefile.am`: pass `-DCONFIG_BASE_DIR` to `dsp_check_CFLAGS`,
  mirroring how `src/Makefile.am` already does for the FastRPC
  libraries.

### 3. Build hygiene: ignore compiled `test/dsp_check` binary

Added `test/dsp_check` to `.gitignore`, matching the existing entry
for `test/fastrpc_test`.

Fixes: https://github.com/qualcomm/fastrpc/issues/385
CRs-Fixed: 4658995