### PR TITLE
fix farf to parse full 64-bit mask on 32-bit ARM

### DIFF
--- a/src/log_config.c
+++ b/src/log_config.c
@@ -29,6 +29,7 @@
 #include "rpcmem.h"
 #include "verify.h"
 #include <errno.h>
+#include <inttypes.h>
 #include <limits.h>
 #include <poll.h>
 #include <pthread.h>
@@ -240,7 +241,7 @@ static int readLogConfigFromPath(int dom, const char *base, const char *file) {
        log_config_watcher[dom].fileToWatch, path, buf);
 
   // Parse farf file to get logmasks.
-  len = sscanf((const char *)buf, "0x%lx %511s", &farf_logmask, filenames);
+  len = sscanf((const char *)buf, "0x%" SCNx64 " %511s", &farf_logmask, filenames);
 
   if (farf_logmask == LLONG_MAX || farf_logmask == (uint64_t)LLONG_MIN ||
       farf_logmask == 0) {


### PR DESCRIPTION
Summary
Fix an issue where FARF log masks were not parsed correctly on 32-bit ARM platforms.

Changes
The FARF log configuration parser previously used sscanf() with the "%lx" format specifier to parse the FARF log mask. On 32-bit ARM, unsigned long is only 32 bits, so the upper 32 bits of the 64-bit FARF mask could be dropped.
This caused HLOS-side runtime FARF masks using upper 32-bit values to be parsed incorrectly.

Fix
Update the parsing format to use SCNx64 so the full 64-bit FARF mask is parsed correctly across both 32-bit and 64-bit platforms.

Impact
This ensures FARF runtime log masks are handled correctly on 32-bit ARM without affecting 64-bit platforms.

CRs-Fixed: 4666832