### PR TITLE
fastrpc-healthcheck: search libs in LIBDIR

### DIFF
--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -34,7 +34,8 @@ fastrpc_healthcheck_SOURCES = fastrpc_healthcheck.c
 
 # Base compiler flags (always)
 fastrpc_healthcheck_CFLAGS = -I$(top_srcdir)/inc -DUSE_SYSLOG \
-                             -DCONFIG_BASE_DIR='"$(CONFIG_BASE_DIR)"'
+                             -DCONFIG_BASE_DIR='"$(CONFIG_BASE_DIR)"' \
+                             -DLIBDIR='"$(libdir)"'
 
 if ANDROID_CC
 fastrpc_healthcheck_CFLAGS += -DANDROID

--- a/test/fastrpc_healthcheck.c
+++ b/test/fastrpc_healthcheck.c
@@ -31,6 +31,10 @@
 #define CONFIG_BASE_DIR "/usr/share/qcom/"
 #endif
 #define QCOM_BASE_DIR CONFIG_BASE_DIR
+
+#ifndef LIBDIR
+#define LIBDIR "/usr/lib"
+#endif
 #define MACHINE_MODEL_PATH "/sys/firmware/devicetree/base/model"
 
 #ifdef ANDROID
@@ -860,12 +864,24 @@ static void build_usr_lib_dirs(strv_t* out) {
         "/vendor/lib64"
     };
 #else
+    /*
+     * LIBDIR is the configured library directory, which is not always
+     * /usr/lib: multiarch distributions install to a triplet-qualified
+     * path such as /usr/lib/aarch64-linux-gnu. Both are checked as the
+     * FastRPC libraries may come from a differently configured build.
+     */
     const char* stds[] = {
+        LIBDIR,
         "/usr/lib"
     };
 #endif
 
-    for (size_t i=0;i<sizeof(stds)/sizeof(stds[0]); ++i) if (is_dir(stds[i])) vec_push(out, stds[i]);
+    for (size_t i=0;i<sizeof(stds)/sizeof(stds[0]); ++i) {
+        bool dup = false;
+        for (size_t j=0;j<i && !dup; ++j)
+            if (strcmp(stds[i], stds[j]) == 0) dup = true;
+        if (!dup && is_dir(stds[i])) vec_push(out, stds[i]);
+    }
 }
 
 static void usage(const char* argv0) {


### PR DESCRIPTION
build_usr_lib_dirs() hardcodes /usr/lib as the only standard
location to search for the FastRPC user-space libraries, and
dir_has_any() does not recurse. On multiarch distributions the
libraries are installed to a triplet-qualified directory such as
/usr/lib/aarch64-linux-gnu, so the scan finds nothing and
fastrpc_lib_ok stays false.

That feeds straight into offload_capable, so on Debian and
derivatives fastrpc-healthcheck reports

  CDSP  Online  Yes  Yes  No (Missing FastRPC user-space libs)

even on a system where FastRPC works fine and fastrpc_test passes.

Pass the configured $(libdir) as LIBDIR, similarly to
CONFIG_BASE_DIR, and search it in addition to /usr/lib so that
libraries from a differently configured build are still found.
Duplicates are skipped when libdir is /usr/lib.
